### PR TITLE
Improve/feedback dsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.3.0 - Tyranus**:
+
+- Feedback: introduce the "on:" keyword to explicitly declare the type of state that concerns the side effect
+
 **v0.2.0 - Vader**:
 
 - UISystem: unify the UISystem concept for RawState and ViewState

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -626,8 +626,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:twittemb/Feedbacks.git";
 			requirement = {
-				kind = exactVersion;
-				version = 0.2.0;
+				kind = revision;
+				revision = ceca7e90a065cbb67346d0234243f598500ddfc5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "git@github.com:twittemb/Feedbacks.git",
         "state": {
           "branch": null,
-          "revision": "f3acf94c94068b044ede750994dac36de2f4e76f",
-          "version": "0.2.0"
+          "revision": "ceca7e90a065cbb67346d0234243f598500ddfc5",
+          "version": null
         }
       }
     ]

--- a/Examples/Examples/CounterApp/System/CounterApp+System.swift
+++ b/Examples/Examples/CounterApp/System/CounterApp+System.swift
@@ -19,8 +19,13 @@ extension CounterApp.System {
         }
 
         Feedbacks {
-            Feedback(strategy: .cancelOnNewState, sideEffect: CounterApp.SideEffects.decreaseEffect(state:))
-            Feedback(strategy: .cancelOnNewState, sideEffect: CounterApp.SideEffects.increaseEffect(state:))
+            Feedback(on: CounterApp.States.Decreasing.self,
+                     strategy: .cancelOnNewState,
+                     sideEffect: CounterApp.SideEffects.decreaseEffect(state:))
+
+            Feedback(on: CounterApp.States.Increasing.self,
+                     strategy: .cancelOnNewState,
+                     sideEffect: CounterApp.SideEffects.increaseEffect(state:))
         }
         .onStateReceived {
             print("Counter: New state has been received: \($0)")

--- a/Examples/Examples/GiphyApp/Features/GifDetail/System/GifDetail+System.swift
+++ b/Examples/Examples/GiphyApp/Features/GifDetail/System/GifDetail+System.swift
@@ -31,10 +31,10 @@ extension GifDetail.System {
             }
 
             Feedbacks {
-                Feedback(strategy: .cancelOnNewState, sideEffect: loadSideEffect)
+                Feedback(on: GifDetail.States.Loading.self, strategy: .cancelOnNewState, sideEffect: loadSideEffect)
                     .execute(on: DispatchQueue(label: "Load Gif Queue"))
 
-                Feedback(strategy: .cancelOnNewState, sideEffect: toggleFavoriteSideEffect)
+                Feedback(on: GifDetail.States.TogglingFavorite.self, strategy: .cancelOnNewState, sideEffect: toggleFavoriteSideEffect)
                     .execute(on: DispatchQueue(label: "Toggle Favorite Queue"))
             }
             .onStateReceived {

--- a/Examples/Examples/GiphyApp/Features/GifList/System/GifList+System.swift
+++ b/Examples/Examples/GiphyApp/Features/GifList/System/GifList+System.swift
@@ -25,7 +25,7 @@ extension GifList.System {
             }
 
             Feedbacks {
-                Feedback(strategy: .cancelOnNewState, sideEffect: loadSideEffect)
+                Feedback(on: GifList.States.Loading.self , strategy: .cancelOnNewState, sideEffect: loadSideEffect)
                     .execute(on: DispatchQueue(label: "Load Gifs Queue"))
             }
             .onStateReceived {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ let system = System {
     }
 
     Feedbacks {
-        Feedback(strategy: .continueOnNewState) { (state: VolumeState) -> AnyPublisher<Event, Never> in
+        Feedback(on: VolumeState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
             if state.value >= targetedVolume {
                 return Empty().eraseToAnyPublisher()
             }
@@ -45,7 +45,7 @@ let system = System {
             return Just(IncreaseEvent()).eraseToAnyPublisher()
         }
         
-        Feedback(strategy: .continueOnNewState) { (state: VolumeState) -> AnyPublisher<Event, Never> in
+        Feedback(on: VolumeState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
             if state.value <= targetedVolume {
                 return Empty().eraseToAnyPublisher()
             }
@@ -105,7 +105,7 @@ The declarative syntax of Feedbacks allows to alter the behavior of side effects
 
 ```swift
 Feedbacks {
-    Feedback(strategy: .continueOnNewState) { (state: LoadingState) -> AnyPublisher<Event, Never> in
+    Feedback(on: LoadingState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
         performLongRunningOperation()
 	        .map { FinishedLoadingEvent() }
 	        .eraseToAnyPublisher()
@@ -118,11 +118,11 @@ As in SwiftUI, modifiers can be applied to the container:
 
 ```swift
 Feedbacks {
-    Feedback(strategy: .continueOnNewState) { (state: LoadingState) -> AnyPublisher<Event, Never> in
+    Feedback(on: LoadingState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
     	...
     }
     
-    Feedback(strategy: .continueOnNewState) { (state: SelectedState) -> AnyPublisher<Event, Never> in
+    Feedback(on: SelectedState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
     	...
     }
 }
@@ -159,8 +159,8 @@ enum MySideEffects {
 
 let myNetworkService = MyNetworkService()
 let myDatabaseService = MyDatabaseService()
-let mySideEffect = SideEffect.make(MySideEffects.load, arg1: myNetworkService, arg2: myDatabaseService)
-let feedback = Feedback(strategy: .cancelOnNewState, sideEffect: mySideEffect)
+let loadingEffect = SideEffect.make(MySideEffects.load, arg1: myNetworkService, arg2: myDatabaseService)
+let feedback = Feedback(on: LoadingState.self, strategy: .cancelOnNewState, sideEffect: loadingEffect)
 ```
 
 `SideEffect.make()` factories will transform functions with several parameters (up to 6 including the state) into functions with 1 parameter (the state), on the condition of the state being the last one.
@@ -238,17 +238,17 @@ Everytime the RefreshEvent is received, this transition will produce a LoadingSt
 A Feedback is built from a side effect. A side effect is a function that takes a state as a parameter. There are two ways to build a Feedback:
 
 ```swift
-Feedback(strategy: .continueOnNewState) { (state: State) in
+Feedback(on: AnyState.self, strategy: .continueOnNewState) { state in
 	...
 	.map { _ in MyEvent() }
 	.eraseToAnyPublisher()
 }
 ```
 
-This feedback will execute the side effect for any type of state. It could be useful if you want to perform a side effect each time a new state is generated, regardless of the type of State.
+This feedback will execute the side effect whatever the type of state that is produced. It could be useful if you want to perform a side effect each time a new state is generated, regardless of the type of State.
 
 ```swift
-Feedback(strategy: .continueOnNewState) { (state: LoadingState) in
+Feedback(on: LoadingState.self, strategy: .continueOnNewState) { state in
 	...
 	.map { _ in MyEvent() }
 	.eraseToAnyPublisher()

--- a/Tests/FeedbacksTests/System/FeedbacksTests.swift
+++ b/Tests/FeedbacksTests/System/FeedbacksTests.swift
@@ -88,13 +88,13 @@ extension FeedbacksTests {
 
         // Given: a Feedbacks composed of feedbacks which side effect are recording there execution queues
         let sut = Feedbacks {
-            Feedback(strategy: .continueOnNewState) { (state: MockStateA) -> AnyPublisher<Event, Never> in
+            Feedback(on: MockStateA.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                 receivedQueuesA.append(DispatchQueue.currentLabel)
                 return Just(MockEvent(value: 1)).eraseToAnyPublisher()
             }
             .execute(on: DispatchQueue(label: expectedQueueA))
 
-            Feedback(strategy: .continueOnNewState) { (state: MockStateA) -> AnyPublisher<Event, Never> in
+            Feedback(on: MockStateA.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                 receivedQueuesB.append(DispatchQueue.currentLabel)
                 return Just(MockEvent(value: 1)).eraseToAnyPublisher()
             }
@@ -123,13 +123,13 @@ extension FeedbacksTests {
         var feedbackAIsCalled = false
         var feedbackBIsCalled = false
 
-        // Given: two feeedbacks
-        let inputFeedbackA = Feedback(strategy: .continueOnNewState) { (state: State) in
+        // Given: two feedbacks
+        let inputFeedbackA = Feedback(on: AnyState.self, strategy: .continueOnNewState) { state in
             feedbackAIsCalled = true
             return Empty<Event, Never>().eraseToAnyPublisher()
         }
         
-        let inputFeedbackB = Feedback(strategy: .continueOnNewState) { (state: State) in
+        let inputFeedbackB = Feedback(on: AnyState.self, strategy: .continueOnNewState) { state in
             feedbackBIsCalled = true
             return Empty<Event, Never>().eraseToAnyPublisher()
         }
@@ -157,10 +157,10 @@ extension FeedbacksTests {
         let sut = Feedbacks {}
         
         // When: adding a feedback that records its execution
-        let newFeedbacks = sut.add(feedback: Feedback(strategy: .continueOnNewState, sideEffect: { (state) -> AnyPublisher<Event, Never> in
+        let newFeedbacks = sut.add(feedback: Feedback(on: AnyState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
             sideEffectIsExecuted = true
             return Empty().eraseToAnyPublisher()
-        }).execute(on: DispatchQueue.immediateScheduler))
+        }.execute(on: DispatchQueue.immediateScheduler))
         
         // when: executing the feedbacks
         let cancellable = newFeedbacks.eventStream(Just(MockStateA(value: 1)).eraseToAnyPublisher()).sink(receiveValue: { _ in })

--- a/Tests/FeedbacksTests/System/SystemTests.swift
+++ b/Tests/FeedbacksTests/System/SystemTests.swift
@@ -32,7 +32,7 @@ final class SystemTests: XCTestCase {
             }
             
             Feedbacks {
-                Feedback(strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
+                Feedback(on: AnyState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                     receivedStates.append(state)
                     return Just<Event>(MockNextEvent()).eraseToAnyPublisher()
                 }
@@ -76,13 +76,13 @@ final class SystemTests: XCTestCase {
             }
             
             Feedbacks {
-                Feedback(strategy: .continueOnNewState) { (state: MockStateA) -> AnyPublisher<Event, Never> in
+                Feedback(on: MockStateA.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                     receivedFeedbackAQueue.append(DispatchQueue.currentLabel)
                     return Just<Event>(MockNextEvent()).eraseToAnyPublisher()
                 }
                 .execute(on: DispatchQueue(label: expectedFeedbackAQueue))
                 
-                Feedback(strategy: .continueOnNewState) { (state: MockStateB) -> AnyPublisher<Event, Never> in
+                Feedback(on: MockStateB.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                     receivedFeedbackBQueue.append(DispatchQueue.currentLabel)
                     return Just<Event>(MockNextEvent()).eraseToAnyPublisher()
                 }
@@ -133,12 +133,12 @@ final class SystemTests: XCTestCase {
             }
             
             Feedbacks {
-                Feedback(strategy: .continueOnNewState) { (state: MockStateA) -> AnyPublisher<Event, Never> in
+                Feedback(on: MockStateA.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                     receivedSystemQueue.append(DispatchQueue.currentLabel)
                     return Just<Event>(MockNextEvent()).eraseToAnyPublisher()
                 }
                 
-                Feedback(strategy: .continueOnNewState) { (state: MockStateB) -> AnyPublisher<Event, Never> in
+                Feedback(on: MockStateB.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                     receivedSystemQueue.append(DispatchQueue.currentLabel)
                     return Just<Event>(MockNextEvent()).eraseToAnyPublisher()
                 }
@@ -195,28 +195,28 @@ final class SystemTests: XCTestCase {
             }
             
             Feedbacks {
-                Feedback(strategy: .continueOnNewState) { (state: State) -> AnyPublisher<Event, Never> in
+                Feedback(on: AnyState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                     receivedStatesInFeedbackA.append(state)
                     guard state is MockStateA else { return Empty().eraseToAnyPublisher() }
                     return Just<Event>(MockNextEvent()).eraseToAnyPublisher()
                 }
                 .execute(on: DispatchQueue(label: UUID().uuidString))
                 
-                Feedback(strategy: .continueOnNewState) { (state: State) -> AnyPublisher<Event, Never> in
+                Feedback(on: AnyState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                     receivedStatesInFeedbackB.append(state)
                     guard state is MockStateB else { return Empty().eraseToAnyPublisher() }
                     return Just<Event>(MockNextEvent()).eraseToAnyPublisher()
                 }
                 .execute(on: DispatchQueue(label: UUID().uuidString))
                 
-                Feedback(strategy: .continueOnNewState) { (state: State) -> AnyPublisher<Event, Never> in
+                Feedback(on: AnyState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                     receivedStatesInFeedbackC.append(state)
                     guard state is MockStateC else { return Empty().eraseToAnyPublisher() }
                     return Just<Event>(MockNextEvent()).eraseToAnyPublisher()
                 }
                 .execute(on: DispatchQueue(label: UUID().uuidString))
                 
-                Feedback(strategy: .continueOnNewState) { (state: State) -> AnyPublisher<Event, Never> in
+                Feedback(on: AnyState.self, strategy: .continueOnNewState) { state -> AnyPublisher<Event, Never> in
                     receivedStatesInFeedbackD.append(state)
                     guard state is MockStateD else { return Empty().eraseToAnyPublisher() }
                     return Just<Event>(MockNextEvent()).eraseToAnyPublisher()

--- a/Tests/FeedbacksTests/System/UISystemTests.swift
+++ b/Tests/FeedbacksTests/System/UISystemTests.swift
@@ -136,7 +136,7 @@ final class UISystemTests: XCTestCase {
             }
 
             Feedbacks {
-                Feedback(strategy: .continueOnNewState) { (state: MockState) in
+                Feedback(on: MockState.self, strategy: .continueOnNewState) { state in
                     return Just<Event>(MockEvent(value: 1)).setFailureType(to: Never.self).eraseToAnyPublisher()
                 }
             }
@@ -370,7 +370,7 @@ final class UISystemTests: XCTestCase {
             }
 
             Feedbacks {
-                Feedback(strategy: .continueOnNewState) { (state: MockState) in
+                Feedback(on: MockState.self, strategy: .continueOnNewState) { state in
                     return Just<Event>(MockEvent(value: 1)).setFailureType(to: Never.self).eraseToAnyPublisher()
                 }
             }


### PR DESCRIPTION
## Description
This PR brings more expressiveness to the Feedback DSL by introducing the "on:" keyword to explicitly declare the type of state that concerns the side effect.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on the **main** branch and is up-to-date, if not please rebase your branch on the top of **main**
- [x] the commits inside this PR have explicit commit messages
- [x] unit tests cover the new feature or the bug fix
- [x] the feature is documented in the README.md if it makes sense
- [x] the CHANGELOG is up-to-date
