### PR TITLE
system: error when no initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **v0.5.0 - Maul**:
 
 - Transitions: enforce the deterministic output state for `On` transitions
+- System: improve the error message (at compile time) when omitting the initial state in the System declaration
 
 **v0.4.0 - Bane**:
 

--- a/Sources/Feedbacks/System/System.swift
+++ b/Sources/Feedbacks/System/System.swift
@@ -260,4 +260,20 @@ public struct SystemBuilder {
             transitions
         }
     }
+
+    @available(*, unavailable, message: "You cannot create a System without an initial state")
+    public static func buildBlock(
+        _ feedbacks: Feedbacks,
+        _ transitions: Transitions
+    ) -> (InitialState, Feedbacks, Transitions) {
+        fatalError()
+    }
+
+    @available(*, unavailable, message: "You cannot create a System without an initial state")
+    public static func buildBlock(
+        _ feedbacks: Feedbacks,
+        _ transitions: Transitions
+    ) -> System {
+        fatalError()
+    }
 }


### PR DESCRIPTION
## Description
This PR improves the error message (compile time) when omitting the initial state in a System declaration

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on the **main** branch and is up-to-date, if not please rebase your branch on the top of **main**
- [x] the commits inside this PR have explicit commit messages
- [x] unit tests cover the new feature or the bug fix
- [x] the feature is documented in the README.md if it makes sense
- [x] the CHANGELOG is up-to-date
